### PR TITLE
ci(dependabot): move interval to monthly and update all cargo dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,9 +4,11 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    allow:
+      - dependency-type: all
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
## Motivation and Context

By default, dependabot doesn't update indirect dependencies which is something we want.

Weekly dependency update is too often for the current repo activity, so move to monthly.