### PR TITLE
ci(dependabot): increase open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: monthly
     allow:
       - dependency-type: all
+    open-pull-requests-limit: 30
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
## Motivation and Context

The default limit of 5 is easily reached.