### PR TITLE
fix: use no-deps parameter in cargo-metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [ stable, "1.70" ] # Check latest stable and MSRV
+        toolchain: [ stable, "1.72" ] # Check latest stable and MSRV
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ae55615695e768a76899c8411b4ebacfbe525e964f94fd24f0007b10b45cd3"
+checksum = "f6e2fd20c8f8c7cc395f69a86a61eb9d93e1de8fadc00338508cde2ffc656388"
 dependencies = [
  "anstyle",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ include = ["/src/", "/build.rs", "/LICENSE", "/NOTICE"]
 keywords = ["cli", "cargo", "filter", "target"]
 license = "Apache-2.0"
 repository = "https://github.com/stormshield/cargo-ft"
-rust-version = "1.70" # Sync this value with the CI workflow
+rust-version = "1.72" # Sync this value with the CI workflow
 description = "A cargo extension for specifying supported targets for a crate"
 
 [dependencies]
@@ -17,7 +17,7 @@ anstyle = "1.0.5"
 cargo-config2 = "0.1.18"
 cargo_metadata = "0.18.1"
 clap = { version = "4.4.15", features = ["derive"] }
-clap-cargo = { version = "0.13.0", features = ["cargo_metadata"] }
+clap-cargo = { version = "0.14.0", features = ["cargo_metadata"] }
 error-stack = "0.4.1"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,11 +59,17 @@ fn main() -> Result<ExitCode, RuntimeError> {
     .into_iter()
     .flatten();
 
+    let cargo_metadata_options = ["--no-deps"]
+        .into_iter()
+        .chain(manifest_options.clone())
+        .map(|s| s.into())
+        .collect::<Vec<_>>();
+
     eprintln!("{:>12} metadata", note("Collecting"));
     let metadata = ft_args
         .manifest
         .metadata()
-        .other_options(manifest_options.clone().map(ToOwned::to_owned).collect::<Vec<_>>())
+        .other_options(cargo_metadata_options)
         .verbose(true)
         .exec()
         .change_context(context)

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,17 +59,12 @@ fn main() -> Result<ExitCode, RuntimeError> {
     .into_iter()
     .flatten();
 
-    let cargo_metadata_options = ["--no-deps"]
-        .into_iter()
-        .chain(manifest_options.clone())
-        .map(|s| s.into())
-        .collect::<Vec<_>>();
-
     eprintln!("{:>12} metadata", note("Collecting"));
     let metadata = ft_args
         .manifest
         .metadata()
-        .other_options(cargo_metadata_options)
+        .no_deps()
+        .other_options(manifest_options.clone().map(ToOwned::to_owned).collect::<Vec<_>>())
         .verbose(true)
         .exec()
         .change_context(context)


### PR DESCRIPTION
Use `--no-deps` parameter in `cargo-metadata` to improve compilation time.