### PR TITLE
build!: bump MSRV from 1.72 to 1.74

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [ stable, "1.72" ] # Check latest stable and MSRV
+        toolchain: [ stable, "1.74" ] # Check latest stable and MSRV
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     runs-on: ${{ matrix.os }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ include = ["/src/", "/build.rs", "/LICENSE", "/NOTICE"]
 keywords = ["cli", "cargo", "filter", "target"]
 license = "Apache-2.0"
 repository = "https://github.com/stormshield/cargo-ft"
-rust-version = "1.72" # Sync this value with the CI workflow
+rust-version = "1.74" # Sync this value with the CI workflow
 description = "A cargo extension for specifying supported targets for a crate"
 
 [dependencies]


### PR DESCRIPTION
## Motivation and Context

`clap 4.5.0` requires an MSRV of `1.74`.