### PR TITLE
fix: lower lint group priority

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,12 +26,12 @@ serde_json = "1.0.115"
 # for more info see: <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
 [lints.rust]
 unsafe_code = "deny"
-future_incompatible = "warn"
-nonstandard_style = "warn"
-rust_2018_idioms = "warn"
+future_incompatible = { level = "warn", priority = -1 }
+nonstandard_style = { level = "warn", priority = -1 }
+rust_2018_idioms = { level = "warn", priority = -1 }
 
 [lints.clippy]
-all = "warn"
+all = { level = "warn", priority = -1 }
 await_holding_lock = "warn"
 char_lit_as_u8 = "warn"
 checked_conversions = "warn"


### PR DESCRIPTION
## Motivation and Context

A new [clippy lint](https://rust-lang.github.io/rust-clippy/master/index.html#/lint_groups_priority) warned about lint group with same priority as other lints.