### PR TITLE
fix!: remove --exclude when checking for explicit selection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,9 +95,7 @@ fn main() -> Result<ExitCode, RuntimeError> {
         ))
     );
 
-    let selected_is_explicit = !ft_args.workspace.package.is_empty()
-        || !ft_args.workspace.exclude.is_empty()
-        || selected.len() == 1;
+    let selected_is_explicit = !ft_args.workspace.package.is_empty() || selected.len() == 1;
 
     ensure!(
         !selected_is_explicit || selected_unsupported.is_empty(),


### PR DESCRIPTION
## Motivation and Context

The explicit selection check is there to prevent cargo-ft from silently discarding a crate the user explicitly asked to include.
Marking `--exclude` as explicit doesn't really fit this goal and make `cargo-ft` annoying to use.